### PR TITLE
Improve handling of jobs with many files

### DIFF
--- a/create_bags/bag_creator.py
+++ b/create_bags/bag_creator.py
@@ -1,5 +1,5 @@
 import json
-from subprocess import PIPE, Popen
+import subprocess
 
 from .helpers import create_tag
 
@@ -63,11 +63,7 @@ class BagCreator:
 
     def create_dart_job(self):
         """Runs a DART job."""
-        job_json_input = (json.dumps(self.job_params) + "\n").encode()
-        cmd = f"{self.dart_command} --workflow={self.workflow_json} --output-dir={self.tmp_dir}"
-        child = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, close_fds=True)
-        stdout_data, stderr_data = child.communicate(job_json_input)
-        if child.returncode != 0:
-            stdout_message = stdout_data.decode('utf-8') if stdout_data else ""
-            stderr_message = stderr_data.decode('utf-8') if stderr_data else ""
-            raise Exception(stdout_message, stderr_message)
+        with open("job_params.json", "w") as param_file:
+            json.dump(self.job_params, param_file)
+        cmd = f"{self.dart_command} --workflow={self.workflow_json} --output-dir={self.tmp_dir} < job_params.json"
+        subprocess.run(cmd, check=True)

--- a/create_bags/bag_creator.py
+++ b/create_bags/bag_creator.py
@@ -6,10 +6,11 @@ from .helpers import create_tag
 
 class BagCreator:
 
-    def __init__(self, dart_command, workflow_json, tmp_dir):
+    def __init__(self, dart_command, workflow_json, tmp_dir, job_params_file):
         self.dart_command = dart_command
         self.workflow_json = workflow_json
         self.tmp_dir = tmp_dir
+        self.job_params_file = job_params_file
 
     def run(self, refid, ao_uri, begin_date, end_date, rights_ids, files):
         """Uses DART Runner to create a bag.
@@ -63,7 +64,7 @@ class BagCreator:
 
     def create_dart_job(self):
         """Runs a DART job."""
-        with open("job_params.json", "w") as param_file:
+        with open(self.job_params_file, "w") as param_file:
             json.dump(self.job_params, param_file)
-        cmd = f"{self.dart_command} --workflow={self.workflow_json} --output-dir={self.tmp_dir} < job_params.json"
-        subprocess.run(cmd, check=True)
+        cmd = f"{self.dart_command} --workflow={self.workflow_json} --output-dir={self.tmp_dir} < {self.job_params_file}"
+        subprocess.run(cmd, shell=True, check=True)

--- a/create_bags/digitization_pipeline.py
+++ b/create_bags/digitization_pipeline.py
@@ -42,6 +42,7 @@ class DigitizationPipeline:
         self.processed_filepath = self.config["Other"]["processed_list"]
         self.dart_command = self.config["DART"]["dart"]
         self.workflow_json = self.config["DART"]["workflow_json"]
+        self.job_params_file = self.config["DART"]["job_params_file"]
 
     def run(self, rights_ids):
         logging.info("Starting run...")
@@ -66,7 +67,7 @@ class DigitizationPipeline:
                 list_of_files = self.add_files_to_dir(refid, dir_to_bag)
                 begin_date, end_date = format_aspace_date(
                     self.as_client.find_closest_dates(ao_uri))
-                created_bag = BagCreator(self.dart_command, self.workflow_json, self.tmp_dir).run(
+                created_bag = BagCreator(self.dart_command, self.workflow_json, self.tmp_dir, self.job_params_file).run(
                     refid, ao_uri, begin_date, end_date, rights_ids, list_of_files)
                 logging.info(f"Bag successfully created: {created_bag}")
                 rmtree(dir_to_bag)

--- a/local_settings.cfg.example
+++ b/local_settings.cfg.example
@@ -13,6 +13,7 @@ bucket = rac-iiif
 [DART]
 dart = ./dart-runner
 workflow_json = /path/to/workflow.json
+job_params_file = /path/to/job_params.json
 
 [Directories]
 root_dir = /path/to/files

--- a/tests/test_bag_creator.py
+++ b/tests/test_bag_creator.py
@@ -2,7 +2,11 @@ from create_bags.bag_creator import BagCreator
 
 
 def test_construct_job_params():
-    bag_creator = BagCreator("dart_command", "workflow.json", "tmp/dir")
+    bag_creator = BagCreator(
+        "dart_command",
+        "workflow.json",
+        "tmp/dir",
+        "job_params.json")
     bag_creator.refid = "jsdfjp90fsfjlk"
     bag_creator.ao_uri = "/whatever"
     rights_ids = [2, 4]
@@ -19,6 +23,6 @@ def test_construct_job_params():
 
 def test_run_method(mocker):
     mocker.patch('create_bags.bag_creator.BagCreator.create_dart_job')
-    create_bag = BagCreator("dart_command", "workflow.json", "tmp/dir").run(
+    create_bag = BagCreator("dart_command", "workflow.json", "tmp/dir", "job_params.json").run(
         "329d56f6f0424bfb8551d148a125dabb", "ao_uri", "1900-01-01", "1910-12-31", [2, 4], ["/path/to/file1.tif", "/path/to/file2.tif"])
     assert create_bag


### PR DESCRIPTION
Dumps job parameters to a file and simplifies the `subprocess` call to DART Runner. This allows jobs with thousands of files to be processed.